### PR TITLE
[KIALI-419] Add versioning to test meshes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ all:	build-service build-traffic-generator
 
 build-service:
 	@echo About to build the Kiali Test Service
-	make -C test-service clean build docker-build 
+	make -C test-service clean build docker-build
 
 build-traffic-generator:
 	@echo About to build the Kiali Test Traffic Generator

--- a/hack/openshift-deploy.sh
+++ b/hack/openshift-deploy.sh
@@ -32,14 +32,14 @@ function setup {
 
   # get rid of existing deployments
   oc delete all,configmap -n ${namespace} --selector=kiali-test
-  
+
   # grant the namespace the permissions required for envoy to run properly
   oc adm policy add-scc-to-user privileged -z default -n ${namespace}
 }
 
 function deploy_services {
   namespace=${1}
-  
+
   template=${SOURCE_ROOT}/test-service/deploy/openshift/test-app-template.yaml
 
   # deploy services
@@ -50,9 +50,9 @@ function deploy_services {
 
 function deploy_traffic_generator {
   namespace=${1}
-  
+
   template=${SOURCE_ROOT}/traffic-generator/openshift/traffic-generator.yaml
- 
+
   oc create -f ${template} -n ${namespace}
 }
 

--- a/hack/openshift-deploy.sh
+++ b/hack/openshift-deploy.sh
@@ -2,6 +2,10 @@
 
 set -x
 
+# Settings for creating many versions to each service
+RANDOM_VERSIONS=${RANDOM_VERSIONS:-false}
+MAX_NUMBER_OF_VERSIONS=${MAX_NUMBER_OF_VERSIONS:-5}
+
 # Get the directory of this file
 SOURCE_ROOT=$(dirname "${BASH_SOURCE}")/..
 
@@ -47,9 +51,16 @@ function deploy_services {
    oc process -f ${template} -p SERVICE_NAME=${i} -p SERVICE_VERSION=v1 | istioctl kube-inject -f - | oc create -n ${namespace} -f -
   done
 
+  if [[ ${RANDOM_VERSIONS} != 'false' ]]; then
+    let number_of_versions=$(( ( RANDOM % $MAX_NUMBER_OF_VERSIONS ) + 2 ))
+    echo $number_of_versions
+  else
+    let number_of_versions=$MAX_NUMBER_OF_VERSIONS
+  fi
+
   # Deploy other versions for some of the services
   for i in b d f; do
-    for n in $(seq 2 $(( ( RANDOM % 5 )  + 2 ))); do
+    for n in $(seq 2 $number_of_versions); do
       oc process -f ${template} -p SERVICE_NAME=${i} -p SERVICE_VERSION=v${n} | istioctl kube-inject -f - | oc create -n ${namespace} -f -
     done
   done

--- a/hack/openshift-deploy.sh
+++ b/hack/openshift-deploy.sh
@@ -44,7 +44,14 @@ function deploy_services {
 
   # deploy services
   for i in a b c d e f; do
-   oc process -f ${template} -p SERVICE_NAME=${i}  | istioctl kube-inject -f - | oc create -n ${namespace} -f -
+   oc process -f ${template} -p SERVICE_NAME=${i} -p SERVICE_VERSION=v1 | istioctl kube-inject -f - | oc create -n ${namespace} -f -
+  done
+
+  # Deploy other versions for some of the services
+  for i in b d f; do
+    for n in $(seq 2 $(( ( RANDOM % 5 )  + 2 ))); do
+      oc process -f ${template} -p SERVICE_NAME=${i} -p SERVICE_VERSION=v${n} | istioctl kube-inject -f - | oc create -n ${namespace} -f -
+    done
   done
 }
 

--- a/test-service/deploy/docker/Dockerfile
+++ b/test-service/deploy/docker/Dockerfile
@@ -1,5 +1,5 @@
 FROM centos:centos7
-  
+
 LABEL maintainer="Kiali <kiali-dev@googlegroups.com>"
 
 COPY kiali-test-service /opt/kiali/

--- a/test-service/deploy/openshift/test-app-template.yaml
+++ b/test-service/deploy/openshift/test-app-template.yaml
@@ -11,6 +11,9 @@ parameters:
 - name: SERVICE_NAME
   description: The name to use for the service
   required: true
+- name: SERVICE_VERSION
+  description: The version of the deployment
+  value: v1
 - name: IMAGE_NAME
   description: The name to use for the image
   value: kiali/kiali-test-service
@@ -33,6 +36,24 @@ objects:
     - name: http
       port: 80
       targetPort: 8888
+- apiVersion: extensions/v1beta1
+  kind: Deployment
+  metadata:
+    name: ${SERVICE_NAME}-${SERVICE_VERSION}
+  spec:
+    replicas: 1
+    template:
+      metadata:
+        labels:
+          app: ${SERVICE_NAME}
+          version: ${SERVICE_VERSION}
+      spec:
+        containers:
+        - name: details
+          image: kiali/kiali-test-service
+          imagePullPolicy: IfNotPresent
+          ports:
+          - containerPort: 8888
 - kind: ReplicaSet
   apiVersion: extensions/v1beta1
   metadata:


### PR DESCRIPTION
This generates a random number of versions for some services (currently from 2 to 5), so that traffic goes through all versions.

![Graph representing the deployments and services](https://i.imgur.com/hwrrUV6.png)