### PR TITLE
[KIALI-646] Keep only ReplicaSet on the Template

### DIFF
--- a/hack/openshift-deploy.sh
+++ b/hack/openshift-deploy.sh
@@ -44,24 +44,25 @@ function setup {
 function deploy_services {
   namespace=${1}
 
-  template=${SOURCE_ROOT}/test-service/deploy/openshift/test-app-template.yaml
+  local service_template=${SOURCE_ROOT}/test-service/deploy/openshift/service-template.yaml
+  local app_template=${SOURCE_ROOT}/test-service/deploy/openshift/app-template.yaml
 
   # deploy services
   for i in a b c d e f; do
-   oc process -f ${template} -p SERVICE_NAME=${i} -p SERVICE_VERSION=v1 | istioctl kube-inject -f - | oc create -n ${namespace} -f -
+   oc process -f ${service_template} -p SERVICE_NAME=${i} | istioctl kube-inject -f - | oc create -n ${namespace} -f -
   done
 
   if [[ ${RANDOM_VERSIONS} != 'false' ]]; then
-    let number_of_versions=$(( ( RANDOM % $MAX_NUMBER_OF_VERSIONS ) + 2 ))
+    let number_of_versions=$(( ( RANDOM % $MAX_NUMBER_OF_VERSIONS ) + 1 ))
     echo $number_of_versions
   else
     let number_of_versions=$MAX_NUMBER_OF_VERSIONS
   fi
 
   # Deploy other versions for some of the services
-  for i in b d f; do
-    for n in $(seq 2 $number_of_versions); do
-      oc process -f ${template} -p SERVICE_NAME=${i} -p SERVICE_VERSION=v${n} | istioctl kube-inject -f - | oc create -n ${namespace} -f -
+  for i in a b c d e f; do
+    for n in $(seq 1 $number_of_versions); do
+      oc process -f ${app_template} -p SERVICE_NAME=${i} -p SERVICE_VERSION=v${n} | istioctl kube-inject -f - | oc create -n ${namespace} -f -
     done
   done
 }

--- a/hack/test-configs/test-box.yaml
+++ b/hack/test-configs/test-box.yaml
@@ -5,6 +5,6 @@ metadata:
   labels:
     kiali-test: traffic-generator-config
 data:
-  duration: "0s"
+  duration: "0"
   route: http://a/route?path=a,b,d,c,a,d,c,b
   rate: "20"

--- a/hack/test-configs/test-breadth.yaml
+++ b/hack/test-configs/test-breadth.yaml
@@ -5,6 +5,6 @@ metadata:
   labels:
     kiali-test: traffic-generator-config
 data:
-  duration: "0s"
+  duration: "0"
   route: http://a/route?path=a;http://a/route?path=b;http://a/route?path=c;http://a/route?path=d;http://a/route?path=e;http://a/route?path=f
   rate: "20"

--- a/hack/test-configs/test-circle-callback.yaml
+++ b/hack/test-configs/test-circle-callback.yaml
@@ -5,6 +5,6 @@ metadata:
   labels:
     kiali-test: traffic-generator-config
 data:
-  duration: "0s"
+  duration: "0"
   route: http://a/route?path=a,b,c,d,e,f,a;http://a/route?path=a,f,e,d,c,b,a
   rate: "20"

--- a/hack/test-configs/test-circle.yaml
+++ b/hack/test-configs/test-circle.yaml
@@ -5,6 +5,6 @@ metadata:
   labels:
     kiali-test: traffic-generator-config
 data:
-  duration: "0s"
+  duration: "0"
   route: http://a/route?path=a,b,c,d,e,f,a
   rate: "20"

--- a/hack/test-configs/test-depth.yaml
+++ b/hack/test-configs/test-depth.yaml
@@ -5,6 +5,6 @@ metadata:
   labels:
     kiali-test: traffic-generator-config
 data:
-  duration: "0s"
+  duration: "0"
   route: http://a/route?path=a,b,c,d,e,f
   rate: "20"

--- a/hack/test-configs/test-hourglass.yaml
+++ b/hack/test-configs/test-hourglass.yaml
@@ -5,6 +5,6 @@ metadata:
   labels:
     kiali-test: traffic-generator-config
 data:
-  duration: "0s"
+  duration: "0"
   route: http://a/route?path=a,b,c,d,e;http://a/route?path=a,c,e
   rate: "20"

--- a/test-service/deploy/openshift/app-template.yaml
+++ b/test-service/deploy/openshift/app-template.yaml
@@ -29,11 +29,11 @@ objects:
     replicas: 1
     selector:
       matchLabels:
-        kiali: test-service-${SERVICE_NAME}-${SERVICE_VERSION}
+        kiali: test-service-${SERVICE_NAME}
     template:
       metadata:
         labels:
-          kiali: test-service-${SERVICE_NAME}-${SERVICE_VERSION}
+          kiali: test-service-${SERVICE_NAME}
           app: ${SERVICE_NAME}
       spec:
         containers:

--- a/test-service/deploy/openshift/app-template.yaml
+++ b/test-service/deploy/openshift/app-template.yaml
@@ -29,12 +29,13 @@ objects:
     replicas: 1
     selector:
       matchLabels:
-        kiali: test-service-${SERVICE_NAME}
+        kiali-test: test-service-${SERVICE_NAME}
     template:
       metadata:
         labels:
-          kiali: test-service-${SERVICE_NAME}
+          kiali-test: test-service-${SERVICE_NAME}
           app: ${SERVICE_NAME}
+          version: ${SERVICE_VERSION}
       spec:
         containers:
           - name: kiali-test-service-${SERVICE_NAME}-${SERVICE_VERSION}

--- a/test-service/deploy/openshift/app-template.yaml
+++ b/test-service/deploy/openshift/app-template.yaml
@@ -1,8 +1,8 @@
 id: kiali-test-service
 kind: Template
 apiVersion: v1
-name: Kiali Test Service Template
-description: Deploys an example service replicaset with a service
+name: Kiali Test Application
+description: Deploys replicasets for the test mesh
 metadata:
   name: kiali-test-service
   labels:
@@ -21,20 +21,6 @@ parameters:
   description: The name to use for the image version
   value: latest
 objects:
-- kind: Service
-  apiVersion: v1
-  metadata:
-    name: ${SERVICE_NAME}
-    labels:
-      kiali: test-service-${SERVICE_NAME}
-      app: ${SERVICE_NAME}
-  spec:
-    selector:
-      kiali: test-service-${SERVICE_NAME}-${SERVICE_VERSION}
-    ports:
-    - name: http
-      port: 80
-      targetPort: 8888
 - kind: ReplicaSet
   apiVersion: extensions/v1beta1
   metadata:

--- a/test-service/deploy/openshift/service-template.yaml
+++ b/test-service/deploy/openshift/service-template.yaml
@@ -23,11 +23,11 @@ objects:
   metadata:
     name: ${SERVICE_NAME}
     labels:
-      kiali: test-service-${SERVICE_NAME}
+      kiali-test: test-service-${SERVICE_NAME}
       app: ${SERVICE_NAME}
   spec:
     selector:
-      kiali: test-service-${SERVICE_NAME}
+      kiali-test: test-service-${SERVICE_NAME}
     ports:
     - name: http
       port: 80

--- a/test-service/deploy/openshift/service-template.yaml
+++ b/test-service/deploy/openshift/service-template.yaml
@@ -1,0 +1,34 @@
+id: kiali-test-service
+kind: Template
+apiVersion: v1
+name: Kiali Test Service Template
+description: Deploys a service for the test mesh
+metadata:
+  name: kiali-test-service
+  labels:
+    kiali-test: test-service
+parameters:
+- name: SERVICE_NAME
+  description: The name to use for the service
+  required: true
+- name: IMAGE_NAME
+  description: The name to use for the image
+  value: kiali/kiali-test-service
+- name: IMAGE_VERSION
+  description: The name to use for the image version
+  value: latest
+objects:
+- kind: Service
+  apiVersion: v1
+  metadata:
+    name: ${SERVICE_NAME}
+    labels:
+      kiali: test-service-${SERVICE_NAME}
+      app: ${SERVICE_NAME}
+  spec:
+    selector:
+      kiali: test-service-${SERVICE_NAME}
+    ports:
+    - name: http
+      port: 80
+      targetPort: 8888

--- a/test-service/deploy/openshift/test-app-template.yaml
+++ b/test-service/deploy/openshift/test-app-template.yaml
@@ -26,51 +26,32 @@ objects:
   metadata:
     name: ${SERVICE_NAME}
     labels:
-      kiali-test: test-service
-      kiali-test: test-service-${SERVICE_NAME}
+      kiali: test-service-${SERVICE_NAME}
       app: ${SERVICE_NAME}
   spec:
     selector:
-      kiali-test: test-service-${SERVICE_NAME}
+      kiali: test-service-${SERVICE_NAME}-${SERVICE_VERSION}
     ports:
     - name: http
       port: 80
       targetPort: 8888
-- apiVersion: extensions/v1beta1
-  kind: Deployment
-  metadata:
-    name: ${SERVICE_NAME}-${SERVICE_VERSION}
-  spec:
-    replicas: 1
-    template:
-      metadata:
-        labels:
-          app: ${SERVICE_NAME}
-          version: ${SERVICE_VERSION}
-      spec:
-        containers:
-        - name: details
-          image: kiali/kiali-test-service
-          imagePullPolicy: IfNotPresent
-          ports:
-          - containerPort: 8888
 - kind: ReplicaSet
   apiVersion: extensions/v1beta1
   metadata:
-    name: kiali-test-service-${SERVICE_NAME}
+    name: kiali-test-service-${SERVICE_NAME}-${SERVICE_VERSION}
   spec:
     replicas: 1
     selector:
       matchLabels:
-        kiali-test: test-service-${SERVICE_NAME}
+        kiali: test-service-${SERVICE_NAME}-${SERVICE_VERSION}
     template:
       metadata:
         labels:
-          kiali-test: test-service-${SERVICE_NAME}
+          kiali: test-service-${SERVICE_NAME}-${SERVICE_VERSION}
           app: ${SERVICE_NAME}
       spec:
         containers:
-          - name: kiali-test-service-${SERVICE_NAME}
+          - name: kiali-test-service-${SERVICE_NAME}-${SERVICE_VERSION}
             image: ${IMAGE_NAME}:${IMAGE_VERSION}
             imagePullPolicy: IfNotPresent
             ports:


### PR DESCRIPTION
After merging #6, we had deployment and replicaset on the template.
Removing and leaving only replicaSet