### PR TITLE
[KIALI-706] Adding Ansible Version and Pip Module requirements on README

### DIFF
--- a/test-service/deploy/ansible/README.adoc
+++ b/test-service/deploy/ansible/README.adoc
@@ -4,6 +4,10 @@
 
 toc::[]
 
+== Dependecies
+- Ansible 2.5+ (`sudo dnf install ansible`)
+- Openshift Pip Module (`pip install openshift`)
+
 == Introduction
 Ansible installer for Kiali Test Mesh
 


### PR DESCRIPTION
I forgot to add on last PR #15, the requirements needed to use ansible 2.5+ and pip module