### PR TITLE
Defining Kiali Hourglass Route

### DIFF
--- a/test-service/deploy/ansible/deploy_test_multiple_namespaces_meshes.yml
+++ b/test-service/deploy/ansible/deploy_test_multiple_namespaces_meshes.yml
@@ -30,7 +30,8 @@
         kiali_test_depth_sink_namespace: ""
         kiali_test_breadth_sink_route: ""
         kiali_test_breadth_sink_namespace: ""
-
+        kiali_test_hourglass_route: ""
+        
     - name: 'check if number_of_namespaces is greater than number_of_services'
       fail: msg="Please make sure the number_of_services are greater than or equal to number_of_namespaces"
       when: "number_of_namespaces  > number_of_services "


### PR DESCRIPTION
Since kiali_hourglass_route is not defined, it causes a problem on the playbook.

Defining the variable, prevent that error to happen

TASK [Deploy Traffic Generator ConfigMaps to Kiali Namespaces] *****************
fatal: [localhost]: FAILED! => {"msg": "'kiali_test_hourglass_route' is undefined"}
	to retry, use: --limit @/home/jenkins/workspace/Kiali-Test-Meshes-Ansible/checkout-directory/test-service/deploy/ansible/deploy_test_multiple_namespaces_meshes.retry
