### PR TITLE
KIALI-1956 Kiali Traffic Generator prints on Openshift Logs Tab

### DIFF
--- a/traffic-generator/docker/traffic-generator.sh
+++ b/traffic-generator/docker/traffic-generator.sh
@@ -6,5 +6,12 @@ for i in "${!array[@]}"
 do
     echo "GET ${array[i]}" >> targets.txt
 done
-touch results.bin
-vegeta attack -targets=targets.txt -rate=${RATE} -duration=${DURATION} >> results.bin & tail -f results.bin | vegeta report
+touch results.json
+vegeta attack -targets=targets.txt -rate=${RATE} -duration=${DURATION} >> results.json &
+sleep 3
+while true; do
+   vegeta report results.json
+   sleep 2
+   echo ""
+   echo ""
+done


### PR DESCRIPTION
After some time suffering from different solutions which didn't work, I have spent some time trying to figure it out why it wasn't working.

## Reason 1 (Vegeta runs Forever)
Since Vegeta runs forever, it will not allow executing the next command on a shell script. So it needs to be executed in the background. A simple `&` does the work

## Reason 2 (Watch doesn't work on Openshift Logs Terminal)

I have tried to use `watch` command, but I faced an issue with no terminal type (https://andykdocs.de/development/Docker/Fixing+the+Docker+TERM+variable+issue), exporting `xterm`, the process start... but the openshift logs tab doesn't show anything.

## Reason 3 (Tail and Cat were being executed on background)

Tail and cat are going to be executed on the background on the previous traffic-generator and background means no log on openshift logs tab.


## Result

- Now we will have the complete log, every two seconds
![peek 2018-11-30 01-12](https://user-images.githubusercontent.com/2313749/49266428-5588a100-f43d-11e8-8904-083347103086.gif)




