### PR TITLE
KIALI-2254 Add a redirected virtualservice to the test mesh

### DIFF
--- a/ansible/deploy_complex_test_mesh.yml
+++ b/ansible/deploy_complex_test_mesh.yml
@@ -90,6 +90,16 @@
       with_items:
       - { namespace: 'kiali-test-ratings', file: 'templates/app-replication-controller.yml', name: 'ratingsv7', app: 'ratings', version: 'v7', sidecar: true }
 
+    - name: Create the Details VS
+      include: tasks/deploy_virtualservice.yml
+      with_items:
+      - { namespace: 'kiali-test-frontend', name: 'detailsvs', host: 'kiali.io', destination_host: 'details', destination_subset: 'v1' }
+
+    - name: Create the Details DR
+      include: tasks/deploy_destinationrule.yml
+      with_items:
+      - { namespace: 'kiali-test-frontend', name: 'detailsdr', host: 'details', subset_name: 'v1', subset_version: 'v1' }
+
     - name: Check if ReplicaSet/Deployment are running as expected before deploying traffic-generator
       include: tasks/checker_app.yml
       with_items:
@@ -114,4 +124,4 @@
     - name: Create the traffic generator
       include: tasks/deploy_traffic_generator.yml
       with_items:
-      - { namespace: 'kiali-test-frontend', route: 'http://productpage/route?path=details;http://productpage/route?path=reviews.kiali-test-reviews.svc.cluster.local,ratings.kiali-test-ratings.svc.cluster.local' }
+      - { namespace: 'kiali-test-frontend', route: 'http://productpage/route?path=kiali.io;http://productpage/route?path=reviews.kiali-test-reviews.svc.cluster.local,ratings.kiali-test-ratings.svc.cluster.local' }

--- a/ansible/tasks/deploy_destinationrule.yml
+++ b/ansible/tasks/deploy_destinationrule.yml
@@ -1,0 +1,2 @@
+- name: Deploy Kiali Test Meshes Destination Rule
+  shell: "cat templates/destinationrule-template.yml | DESTINATION_RULE_NAME={{ item.name }} DESTINATION_RULE_HOST={{ item.host }} SUBSET_NAME={{item.subset_name}} SUBSET_VERSION={{item.subset_version}} envsubst | oc  apply -n {{ item.namespace }} -f -"

--- a/ansible/tasks/deploy_item.yml
+++ b/ansible/tasks/deploy_item.yml
@@ -2,7 +2,6 @@
   shell: "oc process -f {{item.file}} -p NAME={{ item.name }} -p APP_NAME={{ item.app }} -p APP_VERSION={{ item.version }} | istioctl kube-inject -f - | oc  apply -n {{ item.namespace }} -f -"
   when: "item.app is defined and item.sidecar == true"
 
-
 - name: Deploy {{ item.name }} without Sidecar
   shell: "oc process -f {{item.file}} -p NAME={{ item.name }} -p APP_NAME={{ item.app }} -p APP_VERSION={{ item.version }}  | oc  apply -n {{ item.namespace }} -f -"
   when: "item.app is defined and item.sidecar == false"

--- a/ansible/tasks/deploy_virtualservice.yml
+++ b/ansible/tasks/deploy_virtualservice.yml
@@ -1,0 +1,2 @@
+- name: Deploy Kiali Test Meshes VirtualService
+  shell: "cat templates/virtualservice-template.yml | VIRTUAL_SERVICE_NAME=detailsvs VIRTUAL_SERVICE_HOST=kiali.io DESTINATION_HOST=details DESTINATION_SUBSET=v1 envsubst | oc create -f -"

--- a/ansible/templates/destinationrule-template.yml
+++ b/ansible/templates/destinationrule-template.yml
@@ -1,0 +1,10 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: ${DESTINATION_RULE_NAME}
+spec:
+  host: ${DESTINATION_RULE_HOST}
+  subsets:
+  - name: ${SUBSET_NAME}
+    labels:
+      version: ${SUBSET_VERSION}

--- a/ansible/templates/virtualservice-template.yml
+++ b/ansible/templates/virtualservice-template.yml
@@ -1,0 +1,13 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: ${VIRTUAL_SERVICE_NAME}
+spec:
+  hosts:
+  - ${VIRTUAL_SERVICE_HOST}
+  http:
+  - route:
+    - destination:
+        host: ${DESTINATION_HOST}
+        subset: ${DESTINATION_SUBSET}
+      weight: 100


### PR DESCRIPTION
Updates the complex test mesh to add in a virtualservice that takes traffic going to one host and redirects it to another.

In this case, we have traffic from the 'productpage' going to 'kiali.io' that gets redirected to the 'details' service.