### PR TITLE
Watch dependent resources as false

### DIFF
--- a/operator/build/Dockerfile
+++ b/operator/build/Dockerfile
@@ -1,0 +1,5 @@
+FROM quay.io/operator-framework/ansible-operator:v0.8.1
+
+COPY roles/ ${HOME}/roles/
+COPY watches.yaml ${HOME}/watches.yaml
+USER root

--- a/operator/deploy/operator.yaml
+++ b/operator/deploy/operator.yaml
@@ -27,6 +27,9 @@ spec:
           - mountPath: /tmp/ansible-operator/runner
             name: runner
             readOnly: true
+          env:
+            - name: ANSIBLE_VERBOSITY
+              value: "2"
         - name: operator
           image: ${IMAGE}
           imagePullPolicy: "Always"

--- a/operator/watches.yaml
+++ b/operator/watches.yaml
@@ -4,6 +4,7 @@
   kind: Bookinfo
   role: /opt/ansible/roles/bookinfo
   reconcilePeriod: 0
+  watchDependentResources: False
   manageStatus: false
 
 - version: v1
@@ -11,6 +12,7 @@
   kind: ComplexMesh
   role: /opt/ansible/roles/complex_mesh
   reconcilePeriod: 0
+  watchDependentResources: False
   manageStatus: false
 
 - version: v1
@@ -18,4 +20,5 @@
   kind: RedHatTutorial
   role: /opt/ansible/roles/redhat_tutorial
   reconcilePeriod: 0
+  watchDependentResources: False
   manageStatus: false


### PR DESCRIPTION
Because of https://github.com/operator-framework/operator-sdk/issues/155. 
I am adding a workaround for not recreate the dependent resources as found by @jmazzitelli  on https://github.com/operator-framework/operator-sdk/issues/1550#issuecomment-501851718