### PR TITLE
make the replicaset valid again

### DIFF
--- a/traffic-generator/openshift/traffic-generator.yaml
+++ b/traffic-generator/openshift/traffic-generator.yaml
@@ -7,6 +7,10 @@ metadata:
     kiali-test: traffic-generator
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: kiali-traffic-generator
+      kiali-test: traffic-generator
   strategy:
     type: Recreate
   template:


### PR DESCRIPTION
It looks like PR #65 broke the traffic gen ReplicaSet. You now get this error:


```
$ curl https://raw.githubusercontent.com/kiali/kiali-test-mesh/master/traffic-generator/openshift/traffic-generator.yaml | oc apply -f -
The ReplicaSet "kiali-traffic-generator" is invalid: 
* spec.selector: Required value
* spec.template.metadata.labels: Invalid value: map[string]string{"app":"kiali-traffic-generator", "kiali-test":"traffic-generator"}: `selector` does not match template `labels`
```

This PR adds the required selector.