### PR TITLE
Updating Scale Mesh to new Service Mesh 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,12 +92,6 @@ deploy-scale-mesh:
 remove-scale-mesh:
 	cat operator/deploy/cr/scale_mesh-cr.yaml | CONTROL_PLANE_NAMESPACE=${CONTROL_PLANE_NAMESPACE} CONTROL_PLANE_NAME=${CONTROL_PLANE_NAME} SCALE_MESH_NUMBER_SERVICES=${SCALE_MESH_NUMBER_SERVICES} SCALE_MESH_NUMBER_VERSIONS=${SCALE_MESH_NUMBER_VERSIONS} SCALE_MESH_NUMBER_NAMESPACES=${SCALE_MESH_NUMBER_NAMESPACES} SCALE_MESH_TYPE=${SCALE_MESH_TYPE} SCALE_MESH_NUMBER_APPS=${SCALE_MESH_NUMBER_APPS} envsubst | oc delete -f - -n ${KIALI_TEST_MESH_OPERATOR_NAMESPACE}
 
-deploy-scale-mesh-with-playbook: 
-	ansible-playbook operator/scale_mesh.yml -e '{"control_plane_namespace": "${CONTROL_PLANE_NAMESPACE}", "control_plane_name": "${CONTROL_PLANE_NAME}", "number_services": "${SCALE_MESH_NUMBER_SERVICES}", "number_apps": "${SCALE_MESH_NUMBER_APPS}", "number_versions": "${SCALE_MESH_NUMBER_VERSIONS}", "number_namespaces": "${SCALE_MESH_NUMBER_NAMESPACES}", "mesh_type": "${SCALE_MESH_TYPE}" }' -v
-
-remove-scale-mesh-with-playbook: 
-	ansible-playbook operator/scale_mesh.yml -e '{"control_plane_namespace": "${CONTROL_PLANE_NAMESPACE}", "control_plane_name": "${CONTROL_PLANE_NAME}", "number_services": "${SCALE_MESH_NUMBER_SERVICES}", "number_apps": "${SCALE_MESH_NUMBER_APPS}", "number_versions": "${SCALE_MESH_NUMBER_VERSIONS}", "number_namespaces": "${SCALE_MESH_NUMBER_NAMESPACES}", "mesh_type": "${SCALE_MESH_TYPE}", "state": "absent" }' -v
-
 add-bookinfo-control-plane: 
 ifeq ($(ENABLE_MULTI_TENANT),true) 
 	oc patch servicemeshmemberroll default -n ${CONTROL_PLANE_NAMESPACE} --type='json' -p='[{"op": "add", "path": "/spec/members/0", "value":"${BOOKINFO_NAMESPACE}"}]'

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,8 @@ BOOKINFO_VERSION ?= 1.15.0
 BOOKINFO_MYSQL ?= true
 BOOKINFO_MONGODB ?= true
 CONTROL_PLANE_NAMESPACE ?= istio-system
-CONTROL_PLANE_NAME=basic-install
 REDHAT_TUTORIAL_NAMESPACE ?= redhat-istio-tutorial
-OPERATOR_IMAGE ?= quay.io/kiali/kiali-test-mesh-operator:testing
+OPERATOR_IMAGE ?= quay.io/kiali/kiali-test-mesh-operator:latest
 KIALI_TEST_MESH_LABEL ?= kiali-test-mesh-operator=owned
 ENABLE_MULTI_TENANT ?= true
 

--- a/README.adoc
+++ b/README.adoc
@@ -171,14 +171,14 @@ Variables to control the size, type and scale of the mesh
 
 The following are the types of scale meshes you can deploy.
 
-* kiali-test-depth
-* kiali-test-breadth
-* kiali-test-circle
-* kiali-test-circle-callback
-* kiali-test-hourglass
-* kiali-test-depth-sink
-* kiali-test-breadth-sink
+* mesh-depth
+* mesh-breadth
+* mesh-circle
+* mesh-circle-callback
+* mesh-hourglass
+* mesh-depth-sink
+* mesh-breadth-sink
 
 
 Example of the command:
-`SCALE_MESH_NUMBER_SERVICES=6 SCALE_MESH_NUMBER_APPS=6 SCALE_MESH_NUMBER_VERSIONS=2 SCALE_MESH_NUMBER_NAMESPACES=1 SCALE_MESH_TYPE_OF_MESH=kiali-test-circle make-deploy-scale-mesh`
+`SCALE_MESH_NUMBER_SERVICES=6 SCALE_MESH_NUMBER_APPS=6 SCALE_MESH_NUMBER_VERSIONS=2 SCALE_MESH_NUMBER_NAMESPACES=1 SCALE_MESH_TYPE_OF_MESH=mesh-circle make-deploy-scale-mesh`

--- a/operator/build/Dockerfile
+++ b/operator/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/operator-framework/ansible-operator:v0.16.0
+FROM quay.io/operator-framework/ansible-operator:master
 
 COPY roles/ ${HOME}/roles/
 COPY watches.yaml ${HOME}/watches.yaml

--- a/operator/deploy/cr/scale_mesh-cr.yaml
+++ b/operator/deploy/cr/scale_mesh-cr.yaml
@@ -3,12 +3,12 @@ kind: ScaleMesh
 metadata:
   name: scalemesh-installation
 spec:
-  scale_mesh:
-    control_plane_namespace: ${CONTROL_PLANE_NAMESPACE}
-    number_services: ${SCALE_MESH_NUMBER_SERVICES}
-    number_apps: ${SCALE_MESH_NUMBER_APPS}
-    number_namespaces: ${SCALE_MESH_NUMBER_NAMESPACES}
-    number_versions: ${SCALE_MESH_NUMBER_VERSIONS}
-    mesh_type: ${SCALE_MESH_TYPE_OF_MESH}
+  control_plane_namespace: ${CONTROL_PLANE_NAMESPACE}
+  control_plane_name: ${CONTROL_PLANE_NAME}
+  number_services: ${SCALE_MESH_NUMBER_SERVICES}
+  number_apps: ${SCALE_MESH_NUMBER_APPS}
+  number_namespaces: ${SCALE_MESH_NUMBER_NAMESPACES}
+  number_versions: ${SCALE_MESH_NUMBER_VERSIONS}
+  mesh_type: ${SCALE_MESH_TYPE}
 
 

--- a/operator/roles/scale_mesh/defaults/main.yml
+++ b/operator/roles/scale_mesh/defaults/main.yml
@@ -1,12 +1,11 @@
 ---
 # defaults file for scale_mesh
-scale_mesh:
-  control_plane_namespace: istio-system
-  number_services: 6
-  number_versions: 2
-  number_apps: 6
-  number_namespaces: 2
-  mesh_type: kiali-test-depth
+control_plane_namespace: istio-system
+number_services: 6
+number_versions: 2
+number_apps: 6
+number_namespaces: 2
+mesh_type: mesh-depth
 
 full_route: ""
 versions: []

--- a/operator/roles/scale_mesh/meta/main.yml
+++ b/operator/roles/scale_mesh/meta/main.yml
@@ -1,6 +1,6 @@
 galaxy_info:
   author: Guilherme Baufaker Rêgo
-  description: Kiali Test Mesh Operator (Scale Mesh)
+  description: Scale Mesh
   company: Red Hat
 
   # If the issue tracker for your role is not on github, uncomment the
@@ -16,7 +16,7 @@ galaxy_info:
   # - CC-BY
   license: Apache
 
-  min_ansible_version: 2.4
+  min_ansible_version: 2.7
 
   # If this a Container Enabled role, provide the minimum Ansible Container version.
   # min_ansible_container_version:

--- a/operator/roles/scale_mesh/tasks/breadth-route.yml
+++ b/operator/roles/scale_mesh/tasks/breadth-route.yml
@@ -1,8 +1,8 @@
   - name: Set Breadth Route
     vars:
-      fqdn_services_breadth_route: "{{all_services | map(attribute='fqdn') | select('search', 'kiali-test-breadth') | list | difference(all_services | map(attribute='fqdn') | select('search', 'kiali-test-breadth-sink') | list) }}"
+      fqdn_services_breadth_route: "{{all_services | map(attribute='fqdn') | select('search', 'mesh-breadth') | list | difference(all_services | map(attribute='fqdn') | select('search', 'mesh-breadth-sink') | list) }}"
     set_fact:
       full_route: "http://{{fqdn_services_breadth_route[0]}}/route?path={{item}};{{ full_route }}"
-      kiali_test_breadth_namespace: "{{all_services | map(attribute='namespace') | select('search', 'kiali-test-breadth') | list | first }}"
+      kiali_test_breadth_namespace: "{{all_services | map(attribute='namespace') | select('search', 'mesh-breadth') | list | first }}"
     with_items:
       - "{{ fqdn_services_breadth_route | reverse | list  }}"

--- a/operator/roles/scale_mesh/tasks/breadth-sink-route.yml
+++ b/operator/roles/scale_mesh/tasks/breadth-sink-route.yml
@@ -1,8 +1,8 @@
   - name: Set Breadth Sink Route
     vars:
-      fqdn_services_breadth_sink_route: "{{all_services | map(attribute='fqdn') | select('search', 'kiali-test-breadth-sink') | list}}"
+      fqdn_services_breadth_sink_route: "{{all_services | map(attribute='fqdn') | select('search', 'mesh-breadth-sink') | list}}"
     set_fact:
       full_route: "http://{{fqdn_services_breadth_sink_route[0]}}/route?path={{item}},{{fqdn_services_breadth_sink_route[-1]}};{{full_route}}"
-      namespace: "{{all_services | map(attribute='namespace') | select('search', 'kiali-test-breadth-sink') | list | first }}"
+      namespace: "{{all_services | map(attribute='namespace') | select('search', 'mesh-breadth-sink') | list | first }}"
     with_items:
       - "{{ fqdn_services_breadth_sink_route | reverse | list }} "

--- a/operator/roles/scale_mesh/tasks/circle-callback-route.yml
+++ b/operator/roles/scale_mesh/tasks/circle-callback-route.yml
@@ -1,6 +1,6 @@
   - name: Set Circle Callback
     vars:
-      fqdn_services_circle_callback: "{{all_services | map(attribute='fqdn') | select('search', 'kiali-test-circle-callback') | list}}"
+      fqdn_services_circle_callback: "{{all_services | map(attribute='fqdn') | select('search', 'mesh-circle-callback') | list}}"
     set_fact:
       full_route: "http://{{fqdn_services_circle_callback[0]}}/route?path={{ fqdn_services_circle_callback | join(',') }},{{fqdn_services_circle_callback[0]}};http://{{fqdn_services_circle_callback[0]}}/route?path={{fqdn_services_circle_callback[0]}},{{ fqdn_services_circle_callback | reverse | join(',') }}"
-      namespace: "{{all_services | map(attribute='namespace') | select('search', 'kiali-test-circle-callback') | list | first }}"
+      namespace: "{{all_services | map(attribute='namespace') | select('search', 'mesh-circle-callback') | list | first }}"

--- a/operator/roles/scale_mesh/tasks/circle-route.yml
+++ b/operator/roles/scale_mesh/tasks/circle-route.yml
@@ -1,6 +1,6 @@
   - name: Set Circle route
     vars:
-      fqdn_services_circle: "{{all_services | map(attribute='fqdn') | select('search', 'kiali-test-circle') | list | difference(all_services | map(attribute='fqdn') | select('search', 'kiali-test-circle-callback') | list)}}"
+      fqdn_services_circle: "{{all_services | map(attribute='fqdn') | select('search', 'mesh-circle') | list | difference(all_services | map(attribute='fqdn') | select('search', 'mesh-circle-callback') | list)}}"
     set_fact:
-      namespace: "{{all_services | map(attribute='namespace') | select('search', 'kiali-test-circle') | list | first }}"
+      namespace: "{{all_services | map(attribute='namespace') | select('search', 'mesh-circle') | list | first }}"
       full_route: "http://{{fqdn_services_circle[0]}}/route?path={{ fqdn_services_circle | join(',') }},{{fqdn_services_circle[0]}}"

--- a/operator/roles/scale_mesh/tasks/depth-route.yml
+++ b/operator/roles/scale_mesh/tasks/depth-route.yml
@@ -1,6 +1,6 @@
   - name: Set Depth route
     vars:
-      fqdn_services_depth: "{{all_services | map(attribute='fqdn') | select('search', 'kiali-test-depth') | list | difference(all_services | map(attribute='fqdn') | select('search', 'kiali-test-depth-sink') | list)}}"
+      fqdn_services_depth: "{{all_services | map(attribute='fqdn') | select('search', 'mesh-depth') | list | difference(all_services | map(attribute='fqdn') | select('search', 'mesh-depth-sink') | list)}}"
     set_fact:
       full_route: "http://{{fqdn_services_depth[0]}}/route?path={{ fqdn_services_depth | list | join(',') }}"
-      namespace: "{{all_services | map(attribute='namespace') | select('search', 'kiali-test-depth') | list | first }}"
+      namespace: "{{all_services | map(attribute='namespace') | select('search', 'mesh-depth') | list | first }}"

--- a/operator/roles/scale_mesh/tasks/depth-sink-route.yml
+++ b/operator/roles/scale_mesh/tasks/depth-sink-route.yml
@@ -1,8 +1,8 @@
 - name: Set Depth Sink Route
   vars:
-    fqdn_services_depth_sink_route: "{{all_services | map(attribute='fqdn') | select('search', 'kiali-test-depth-sink') | list}}"
+    fqdn_services_depth_sink_route: "{{all_services | map(attribute='fqdn') | select('search', 'mesh-depth-sink') | list}}"
   set_fact:
     full_route: "http://{{fqdn_services_depth_sink_route[0]}}/route?path={{ fqdn_services_depth_sink_route[:(item | int)] | union([fqdn_services_depth_sink_route[-1]]) | join(',') }};{{full_route}}"
-    kiali_test_depth_sink_namespace: "{{all_services | map(attribute='namespace') | select('search', 'kiali-test-depth-sink') | list | first }}"
+    kiali_test_depth_sink_namespace: "{{all_services | map(attribute='namespace') | select('search', 'mesh-depth-sink') | list | first }}"
   when: (item | int) != (scale_mesh.number_services | int)
   with_sequence: start={{scale_mesh.number_services}} end=1 stride=-1 format=%d

--- a/operator/roles/scale_mesh/tasks/hourglass-route.yml
+++ b/operator/roles/scale_mesh/tasks/hourglass-route.yml
@@ -1,7 +1,7 @@
 
   # Generate Even Array in order to make it simple to Hourglass
   - name: Generate Hourglass Even Elements Array
-    set_fact: even_services="{{even_services}} + ['service-{{ item }}.kiali-test-hourglass-{{ (item.0 | int) % (scale_mesh.number_namespaces | int) }}.svc.cluster.local']"
+    set_fact: even_services="{{even_services}} + ['service-{{ item }}.mesh-hourglass-{{ (item.0 | int) % (scale_mesh.number_namespaces | int) }}.svc.cluster.local']"
     when: "(item | int) %2 == 1"
     with_sequence: start=1 end={{ scale_mesh.number_services }} format=%d
 
@@ -9,18 +9,18 @@
   # if the mesh is odd number so we subtract one to make it even
   - name: Hourglass Mesh if length is Odd
     vars:
-      fqdn_services_hourglass: "{{all_services | map(attribute='fqdn') | select('search', 'kiali-test-hourglass') | list}}"
+      fqdn_services_hourglass: "{{all_services | map(attribute='fqdn') | select('search', 'mesh-hourglass') | list}}"
     set_fact:
       full_route: "http://{{fqdn_services_hourglass[0]}}/route?path={{  fqdn_services_hourglass | difference([fqdn_services_hourglass[-1]]) | join(',') }};http://{{fqdn_services_hourglass[0]}}/route?path={{  fqdn_services_hourglass | intersect(even_services) | join(',') }}"
-      namespace: "{{all_services | map(attribute='namespace') | select('search', 'kiali-test-hourglass') | list | first }}"
+      namespace: "{{all_services | map(attribute='namespace') | select('search', 'mesh-hourglass') | list | first }}"
     when: (fqdn_services_hourglass | length % 2 == 0)
 
 
   - name: Hourglass Mesh if length is Even
     vars:
-      fqdn_services_hourglass: "{{all_services | map(attribute='fqdn') | select('search', 'kiali-test-hourglass') | list}}"
+      fqdn_services_hourglass: "{{all_services | map(attribute='fqdn') | select('search', 'mesh-hourglass') | list}}"
     set_fact:
       full_route: "http://{{fqdn_services_hourglass[0]}}/route?path={{  fqdn_services_hourglass | join(',') }};http://{{fqdn_services_hourglass[0]}}/route?path={{  fqdn_services_hourglass | intersect(even_services) | join(',') }}"
-      namespace: "{{all_services | map(attribute='namespace') | select('search', 'kiali-test-hourglass') | list | first }}"
+      namespace: "{{all_services | map(attribute='namespace') | select('search', 'mesh-hourglass') | list | first }}"
     when: (fqdn_services_hourglass | length % 2 == 1)
 

--- a/operator/roles/scale_mesh/tasks/main.yml
+++ b/operator/roles/scale_mesh/tasks/main.yml
@@ -1,26 +1,26 @@
 - name: Generate Versions Array
   set_fact: versions="{{versions}} + ['v{{ item }}']"
-  with_sequence: start=1 end={{scale_mesh.number_versions}} format=%d
+  with_sequence: start=1 end={{number_versions}} format=%d
 
 - name: Generate Services Array
   set_fact: services="{{services}} + ['{{ item }}']"
-  with_sequence: start=1 end={{scale_mesh.number_services}} format=%d
+  with_sequence: start=1 end={{number_services}} format=%d
 
 - name: Generate Apps Array
   set_fact: apps="{{apps}} + ['{{ item }}']"
-  with_sequence: start=1 end={{scale_mesh.number_apps}} format=%d
+  with_sequence: start=1 end={{number_apps}} format=%d
 
 - name: Create Service and Namespace Dict
   set_fact:
   args:
     service:
       name: "service-{{ item.0 }}"
-      namespace: "{{item.1}}-{{ (item.0 | int) % (scale_mesh.number_namespaces | int) }}"
-      fqdn: "service-{{ item.0 }}.{{item.1}}-{{ (item.0 | int) % (scale_mesh.number_namespaces | int) }}.svc.cluster.local"
-      app: "app{{ (item.0 | int) % (scale_mesh.number_apps | int) }}"
+      namespace: "{{item.1}}-{{ (item.0 | int) % (number_namespaces | int) }}"
+      fqdn: "service-{{ item.0 }}.{{item.1}}-{{ (item.0 | int) % (number_namespaces | int) }}.svc.cluster.local"
+      app: "app{{ (item.0 | int) % (number_apps | int) }}"
   with_nested:
     - "{{ services }}"
-    - "{{ scale_mesh.mesh_type }}"
+    - "{{ mesh_type }}"
   register: all_services
 
 - name: Create All Services List
@@ -30,64 +30,64 @@
 
 - name: Create Depth Route
   include_tasks: depth-route.yml
-  when: "scale_mesh.mesh_type == 'kiali-test-depth'"
+  when: "mesh_type == 'mesh-depth'"
 
 - name: Create Circle Callback Route
   include_tasks: circle-callback-route.yml
-  when: "scale_mesh.mesh_type == 'kiali-test-circle-callback'"
+  when: "mesh_type == 'mesh-circle-callback'"
 
 - name: Create Hourglass Route
   include_tasks: hourglass-route.yml
-  when: "scale_mesh.mesh_type == 'kiali-test-hourglass'"
+  when: "mesh_type == 'mesh-hourglass'"
 
 - name: Create Circle Route
   include_tasks: circle-route.yml
-  when: "scale_mesh.mesh_type == 'kiali-test-circle'"
+  when: "mesh_type == 'mesh-circle'"
 
 - name: Create Breadth Sink Route
   include_tasks: breadth-sink-route.yml
-  when: "scale_mesh.mesh_type == 'kiali-test-breadth-sink'"
+  when: "mesh_type == 'mesh-breadth-sink'"
 
 - name: Create Breadth Route
   include_tasks: breadth-route.yml
-  when: "scale_mesh.mesh_type == 'kiali-test-breadth'"
+  when: "mesh_type == 'mesh-breadth'"
 
 - name: Create Depth Sink Route
   include_tasks: depth-sink-route.yml
-  when: "scale_mesh.mesh_type == 'kiali-test-depth-sink'"
+  when: "mesh_type == 'mesh-depth-sink'"
 
 
 - name: Get Namespaces
   set_fact:
     namespaces: "{{ all_services | map(attribute='namespace') | list | unique }}"
+    state_traffic_generator: "{{ state }}"
 
 - name: Configure the namespaces
   k8s:
-    state: present
+    state: "{{ state }}"
     definition: "{{ lookup('template', 'templates/namespace.yml') }}"
   with_items:
   - "{{ namespaces  }}"
 
-- name: Get Service Mesh Member Roll Definitions
-  set_fact:
-    smmr_definition: "{{ lookup('template', 'templates/smmr.yml') }}"
 
-- name: Add Namespaces to Service Mesh Member Roll
+- name: Add Service Mesh Member to namespaces
   k8s:
-    state: present
-    definition:  "{{ smmr_definition }}"
+    state: "{{ state }}"
+    definition: "{{ lookup('template', 'templates/smm.yml') }}"
+  with_items:
+  - "{{ namespaces }}"
   ignore_errors: yes
 
-- name: Deploy Kiali Test Meshes Services
+- name: Deploy Test Meshes Services
   k8s:
-    state: present
+    state: "{{ state }}"
     definition: "{{ lookup('template', 'templates/service.yml') }}"
   with_items:
     - "{{ all_services }}"
 
-- name: Deploy Kiali Test Pods
+- name: Deploy Test Pods
   k8s:
-    state: present
+    state: "{{ state }}"
     definition: "{{ lookup('template', 'templates/deployment.yml') }}"
   with_nested:
   - "{{ all_services }}"
@@ -100,3 +100,4 @@
   vars:
     namespace: "{{ all_services | map(attribute='namespace') | list | unique | first }}"
     route: "{{ full_route }}"
+    state: "{{ state_traffic_generator }}"

--- a/operator/roles/scale_mesh/templates/smm.yml
+++ b/operator/roles/scale_mesh/templates/smm.yml
@@ -1,0 +1,8 @@
+apiVersion: maistra.io/v1
+kind: ServiceMeshMember
+metadata:
+  name: default
+  namespace: {{ item }}
+spec:
+  controlPlaneRef:
+    namespace: {{ control_plane_namespace }}

--- a/operator/roles/scale_mesh/templates/smmr.yml
+++ b/operator/roles/scale_mesh/templates/smmr.yml
@@ -1,8 +1,0 @@
-apiVersion: maistra.io/v1
-kind: ServiceMeshMemberRoll
-metadata:
-  name: default
-  namespace: istio-system
-spec:
-  members:
-    {{ namespaces | to_nice_yaml(indent=4) | trim | indent(4) }}

--- a/operator/roles/scale_mesh/vars/main.yml
+++ b/operator/roles/scale_mesh/vars/main.yml
@@ -1,2 +1,3 @@
 ---
 # vars file for scale_mesh
+state: present

--- a/operator/roles/traffic-generator/tasks/main.yml
+++ b/operator/roles/traffic-generator/tasks/main.yml
@@ -1,11 +1,11 @@
 - name: "Deploy Traffic Generator Configmap in {{ namespace }}"
   k8s:
-   state: present
+   state: "{{ state }}"
    definition: "{{ lookup('template', 'templates/traffic-generator-configmap.yml') }}"
 
 
 - name: "Deploy Traffic Generator in {{ namespace }} with Automatic Injection"
   k8s:
-   state: present
+   state: "{{ state }}"
    definition: "{{ lookup('template', 'templates/traffic-generator.yml') }}"
 

--- a/operator/roles/traffic-generator/vars/main.yml
+++ b/operator/roles/traffic-generator/vars/main.yml
@@ -1,2 +1,3 @@
 ---
 # vars file for traffic-generator
+state: present

--- a/operator/watches.yaml
+++ b/operator/watches.yaml
@@ -4,20 +4,19 @@
   kind: Bookinfo
   role: /opt/ansible/roles/bookinfo
   reconcilePeriod: 0
-  watchDependentResources: False
-  manageStatus: false
 
 - version: v1
   group: scalemesh.kiali.io
   kind: ScaleMesh
   role: /opt/ansible/roles/scale_mesh
-  reconcilePeriod: 0
-  manageStatus: false
+  finalizer:
+    name: finalizer.scalemesh.kiali.io
+    vars:
+      state: absent
+    reconcilePeriod: 0
 
 - version: v1
   group: redhattutorial.kiali.io
   kind: RedHatTutorial
   role: /opt/ansible/roles/redhat_tutorial
   reconcilePeriod: 0
-  watchDependentResources: False
-  manageStatus: false


### PR DESCRIPTION
- Adding `ServiceMeshMember` to the namespaces
- Editing the CR for more straightforward configuration 
- Adding Finalizer for Removal via Openshift UI  
        - Manifests compliance ("coming next PR")


All the changes are available on `quay.io/kiali/kiali-test-mesh-operator:testing` and the CR of scale mesh is updated. A `make deploy-scale-mesh` should be enough after deploying the scale-mesh.